### PR TITLE
Re-enable pip check (django-cryptography-django5 dist-info fixed in _5), build 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -31,8 +31,8 @@ requirements:
 test:
   imports:
     - explorer
-  #commands:
-    #- pip check
+  commands:
+    - pip check
   requires:
     - pip
     - python {{ python_min }}


### PR DESCRIPTION
Re-enables the `pip check` test command that was commented out while conda-forge's `django-cryptography-django5` shipped a dev-version wheel dist-info (`2.2.dev20251005171540`, builds `_0`..`_4`) that false-failed this package's upstream-exact `==2.2` pin. That was fixed in [django-cryptography-django5-feedstock#7](https://github.com/conda-forge/django-cryptography-django5-feedstock/pull/7) (issue [#6](https://github.com/conda-forge/django-cryptography-django5-feedstock/issues/6)); the `_5` rebuild is live and indexed.

Changes: uncomment `commands: - pip check`; build number 1 → 2.

Verified locally (conda-build, linux-64): test env resolved `django-cryptography-django5 2.2-pyhcf101f3_5` from conda-forge; `pip check` → `No broken requirements found.`
